### PR TITLE
Fix lint warnings and errors

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -10,30 +10,24 @@ import (
 	"golang.org/x/exp/slices"
 )
 
-type collector struct {
+type Collector struct {
 	ctx     context.Context
 	target  string
 	modules []string
 	apiKey  string
-	logger  log.Logger
 }
 
-func New(ctx context.Context, target string, modules []string, apiKey string, logger log.Logger) *collector {
-	return &collector{ctx: ctx, target: target, modules: modules, apiKey: apiKey, logger: logger}
+func New(ctx context.Context, target string, modules []string, apiKey string) *Collector {
+	return &Collector{ctx: ctx, target: target, modules: modules, apiKey: apiKey}
 }
 
 // Describe implements Prometheus.Collector.
-func (c collector) Describe(ch chan<- *prometheus.Desc) {
+func (c Collector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- prometheus.NewDesc("dummy", "dummy", nil, nil)
 }
 
-// Regex to match all non valid characters
+// Regex to match all invalid characters
 var prometheusMetricNameInvalidCharactersRegex = regexp.MustCompile(`[^a-zA-Z0-9_]+`)
-
-func getValidMetricName(str string) string {
-	// convert hyphens to underscores and strip out all other invalid characters
-	return prometheusMetricNameInvalidCharactersRegex.ReplaceAllString(strings.Replace(str, "-", "_", -1), "")
-}
 
 func getValidLabelName(str string) string {
 	// convert hyphens to underscores and strip out all other invalid characters
@@ -41,16 +35,16 @@ func getValidLabelName(str string) string {
 }
 
 // Collect implements Prometheus.Collector.
-func (c collector) Collect(ch chan<- prometheus.Metric) {
+func (c Collector) Collect(ch chan<- prometheus.Metric) {
 
 	// Process Stats (and Network Stats)
 	if slices.Contains(c.modules, "process_stats") || slices.Contains(c.modules, "network_stats") {
 
-		c.logger.Infof("Collecting process_stats for %s", c.target)
+		log.Infof("Collecting process_stats for %s", c.target)
 
 		result, err := c.fetchMoonrakerProcessStats(c.target, c.apiKey)
 		if err != nil {
-			c.logger.Error(err)
+			log.Error(err)
 			return
 		}
 
@@ -58,7 +52,7 @@ func (c collector) Collect(ch chan<- prometheus.Metric) {
 		if slices.Contains(c.modules, "process_stats") {
 			memUnits := result.Result.MoonrakerStats[len(result.Result.MoonrakerStats)-1].MemUnits
 			if memUnits != "kB" {
-				c.logger.Errorf("Unexpected units %s for Moonraker memory usage", memUnits)
+				log.Errorf("Unexpected units %s for Moonraker memory usage", memUnits)
 			} else {
 				ch <- prometheus.MustNewConstMetric(
 					prometheus.NewDesc("klipper_moonraker_memory_kb", "Moonraker memory usage in Kb.", nil, nil),
@@ -110,7 +104,7 @@ func (c collector) Collect(ch chan<- prometheus.Metric) {
 			rxErrs := prometheus.NewDesc("klipper_network_rx_errs", "Klipper network received errored packets.", networkLabels, nil)
 			txErrs := prometheus.NewDesc("klipper_network_tx_errs", "Klipper network transmitted errored packets.", networkLabels, nil)
 			rxDrop := prometheus.NewDesc("klipper_network_rx_drop", "Klipper network received dropped packets.", networkLabels, nil)
-			txDrop := prometheus.NewDesc("klipper_network_tx_drop", "Klipper network transmitted dropped packtes.", networkLabels, nil)
+			txDrop := prometheus.NewDesc("klipper_network_tx_drop", "Klipper network transmitted dropped packets.", networkLabels, nil)
 			bandwidth := prometheus.NewDesc("klipper_network_bandwidth", "Klipper network bandwidth.", networkLabels, nil)
 			for key, element := range result.Result.Network {
 				interfaceName := getValidLabelName(key)
@@ -165,7 +159,7 @@ func (c collector) Collect(ch chan<- prometheus.Metric) {
 
 	// Directory Information
 	if slices.Contains(c.modules, "directory_info") {
-		c.logger.Infof("Collecting directory_info for %s", c.target)
+		log.Infof("Collecting directory_info for %s", c.target)
 		result, _ := c.fetchMoonrakerDirectoryInfo(c.target, c.apiKey)
 		ch <- prometheus.MustNewConstMetric(
 			prometheus.NewDesc("klipper_disk_usage_total", "Klipper total disk space.", nil, nil),
@@ -183,7 +177,7 @@ func (c collector) Collect(ch chan<- prometheus.Metric) {
 
 	// Job Queue
 	if slices.Contains(c.modules, "job_queue") {
-		c.logger.Infof("Collecting job_queue for %s", c.target)
+		log.Infof("Collecting job_queue for %s", c.target)
 		result, _ := c.fetchMoonrakerJobQueue(c.target, c.apiKey)
 		ch <- prometheus.MustNewConstMetric(
 			prometheus.NewDesc("klipper_job_queue_length", "Klipper job queue length.", nil, nil),
@@ -193,7 +187,7 @@ func (c collector) Collect(ch chan<- prometheus.Metric) {
 
 	// Job History
 	if slices.Contains(c.modules, "history") {
-		c.logger.Infof("Collecting history for %s", c.target)
+		log.Infof("Collecting history for %s", c.target)
 		result, _ := c.fetchMoonrakerHistory(c.target, c.apiKey)
 		ch <- prometheus.MustNewConstMetric(
 			prometheus.NewDesc("klipper_total_jobs", "Klipper number of total jobs.", nil, nil),
@@ -202,28 +196,28 @@ func (c collector) Collect(ch chan<- prometheus.Metric) {
 		ch <- prometheus.MustNewConstMetric(
 			prometheus.NewDesc("klipper_total_time", "Klipper total time.", nil, nil),
 			prometheus.GaugeValue,
-			float64(result.Result.JobTotals.TotalTime))
+			result.Result.JobTotals.TotalTime)
 		ch <- prometheus.MustNewConstMetric(
 			prometheus.NewDesc("klipper_total_print_time", "Klipper total print time.", nil, nil),
 			prometheus.GaugeValue,
-			float64(result.Result.JobTotals.PrintTime))
+			result.Result.JobTotals.PrintTime)
 		ch <- prometheus.MustNewConstMetric(
 			prometheus.NewDesc("klipper_total_filament_used", "Klipper total meters of filament used.", nil, nil),
 			prometheus.GaugeValue,
-			float64(result.Result.JobTotals.FilamentUsed))
+			result.Result.JobTotals.FilamentUsed)
 		ch <- prometheus.MustNewConstMetric(
 			prometheus.NewDesc("klipper_longest_job", "Klipper total longest job.", nil, nil),
 			prometheus.GaugeValue,
-			float64(result.Result.JobTotals.LongestJob))
+			result.Result.JobTotals.LongestJob)
 		ch <- prometheus.MustNewConstMetric(
 			prometheus.NewDesc("klipper_longest_print", "Klipper total longest print.", nil, nil),
 			prometheus.GaugeValue,
-			float64(result.Result.JobTotals.LongestPrint))
+			result.Result.JobTotals.LongestPrint)
 	}
 
 	// Current Print from Job History
 	if slices.Contains(c.modules, "history") {
-		c.logger.Infof("Collecting active print for %s", c.target)
+		log.Infof("Collecting active print for %s", c.target)
 		result, _ := c.fetchMoonrakerHistoryCurrent(c.target, c.apiKey)
 		ch <- prometheus.MustNewConstMetric(
 			prometheus.NewDesc("klipper_current_print_object_height", "Klipper current print object height", nil, nil),
@@ -245,7 +239,7 @@ func (c collector) Collect(ch chan<- prometheus.Metric) {
 
 	// System Info
 	if slices.Contains(c.modules, "system_info") {
-		c.logger.Infof("Collecting system_info for %s", c.target)
+		log.Infof("Collecting system_info for %s", c.target)
 		result, _ := c.fetchMoonrakerSystemInfo(c.target, c.apiKey)
 		ch <- prometheus.MustNewConstMetric(
 			prometheus.NewDesc("klipper_system_cpu_count", "Klipper system CPU count.", nil, nil),
@@ -256,7 +250,7 @@ func (c collector) Collect(ch chan<- prometheus.Metric) {
 	// Temperature Store
 	// (deprecated since v0.8.0, use `printer_objects` instead)
 	if slices.Contains(c.modules, "temperature") {
-		c.logger.Infof("Collecting system_info for %s", c.target)
+		log.Infof("Collecting system_info for %s", c.target)
 		result, _ := c.fetchTemperatureData(c.target, c.apiKey)
 
 		for k, v := range result.Result {
@@ -275,7 +269,7 @@ func (c collector) Collect(ch chan<- prometheus.Metric) {
 
 	// Printer Objects
 	if slices.Contains(c.modules, "printer_objects") {
-		c.logger.Infof("Collecting printer_objects for %s", c.target)
+		log.Infof("Collecting printer_objects for %s", c.target)
 		result, _ := c.fetchMoonrakerPrinterObjects(c.target, c.apiKey)
 
 		// gcode_move
@@ -328,7 +322,7 @@ func (c collector) Collect(ch chan<- prometheus.Metric) {
 			prometheus.GaugeValue,
 			result.Result.Status.Mcu.LastStats.BytesRetransmit)
 		ch <- prometheus.MustNewConstMetric(
-			prometheus.NewDesc("klipper_mcu_invalid_bytes", "Klipper mcu invalid btyles.", nil, nil),
+			prometheus.NewDesc("klipper_mcu_invalid_bytes", "Klipper mcu invalid bytes.", nil, nil),
 			prometheus.GaugeValue,
 			result.Result.Status.Mcu.LastStats.BytesInvalid)
 		ch <- prometheus.MustNewConstMetric(
@@ -479,7 +473,7 @@ func (c collector) Collect(ch chan<- prometheus.Metric) {
 		// temperature_sensor
 		temperatureSensorLabels := []string{"sensor"}
 		temperatureSensor := prometheus.NewDesc("klipper_temperature_sensor_temperature", "The temperature of the temperature sensor", temperatureSensorLabels, nil)
-		temperatureSensorMinTemp := prometheus.NewDesc("klipper_temperature_sensor_measured_min_temp", "The measured minimun temperature of the temperature sensor", temperatureSensorLabels, nil)
+		temperatureSensorMinTemp := prometheus.NewDesc("klipper_temperature_sensor_measured_min_temp", "The measured minimum temperature of the temperature sensor", temperatureSensorLabels, nil)
 		temperatureSensorMaxTemp := prometheus.NewDesc("klipper_temperature_sensor_measured_max_temp", "The measured maximum temperature of the temperature sensor", temperatureSensorLabels, nil)
 		for sk, sv := range result.Result.Status.TemperatureSensors {
 			sensorName := getValidLabelName(sk)
@@ -539,7 +533,7 @@ func (c collector) Collect(ch chan<- prometheus.Metric) {
 }
 
 // only return metric if current job status is in progress
-func (c collector) checkConditionStatusPrint(result *MoonrakerHistoryCurrentPrintResponse, value float64) float64 {
+func (c Collector) checkConditionStatusPrint(result *MoonrakerHistoryCurrentPrintResponse, value float64) float64 {
 	var valueToReturn float64 = 0
 	if result.Result.Jobs[0].Status == "in_progress" {
 		valueToReturn = value

--- a/collector/directory_information.go
+++ b/collector/directory_information.go
@@ -4,8 +4,8 @@ package collector
 
 import (
 	"encoding/json"
-	"io/ioutil"
-
+	log "github.com/sirupsen/logrus"
+	"io"
 	"net/http"
 )
 
@@ -19,14 +19,14 @@ type MoonrakerDirecotryInfoQueryResponse struct {
 	} `json:"result"`
 }
 
-func (c collector) fetchMoonrakerDirectoryInfo(klipperHost string, apiKey string) (*MoonrakerDirecotryInfoQueryResponse, error) {
+func (c Collector) fetchMoonrakerDirectoryInfo(klipperHost string, apiKey string) (*MoonrakerDirecotryInfoQueryResponse, error) {
 	var url = "http://" + klipperHost + "/server/files/directory?path=gcodes&extended=false"
-	c.logger.Debug("Collecting metrics from " + url)
+	log.Debug("Collecting metrics from " + url)
 
 	client := &http.Client{}
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
-		c.logger.Error(err)
+		log.Error(err)
 		return nil, err
 	}
 	if apiKey != "" {
@@ -34,13 +34,13 @@ func (c collector) fetchMoonrakerDirectoryInfo(klipperHost string, apiKey string
 	}
 	res, err := client.Do(req)
 	if err != nil {
-		c.logger.Error(err)
+		log.Error(err)
 		return nil, err
 	}
 	defer res.Body.Close()
-	data, err := ioutil.ReadAll(res.Body)
+	data, err := io.ReadAll(res.Body)
 	if err != nil {
-		c.logger.Error(err)
+		log.Error(err)
 		return nil, err
 	}
 
@@ -48,7 +48,7 @@ func (c collector) fetchMoonrakerDirectoryInfo(klipperHost string, apiKey string
 
 	err = json.Unmarshal(data, &response)
 	if err != nil {
-		c.logger.Error(err)
+		log.Error(err)
 		return nil, err
 	}
 

--- a/collector/history.go
+++ b/collector/history.go
@@ -4,8 +4,8 @@ package collector
 
 import (
 	"encoding/json"
-	"io/ioutil"
-
+	log "github.com/sirupsen/logrus"
+	"io"
 	"net/http"
 )
 
@@ -60,14 +60,14 @@ type MoonrakerHistoryCurrentPrintResponse struct {
 	} `json:"result"`
 }
 
-func (c collector) fetchMoonrakerHistory(klipperHost string, apiKey string) (*MoonrakerHistoryResponse, error) {
+func (c Collector) fetchMoonrakerHistory(klipperHost string, apiKey string) (*MoonrakerHistoryResponse, error) {
 	var url = "http://" + klipperHost + "/server/history/totals"
-	c.logger.Debug("Collecting metrics from " + url)
+	log.Debug("Collecting metrics from " + url)
 
 	client := &http.Client{}
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
-		c.logger.Error(err)
+		log.Error(err)
 		return nil, err
 	}
 	if apiKey != "" {
@@ -75,13 +75,13 @@ func (c collector) fetchMoonrakerHistory(klipperHost string, apiKey string) (*Mo
 	}
 	res, err := client.Do(req)
 	if err != nil {
-		c.logger.Error(err)
+		log.Error(err)
 		return nil, err
 	}
 	defer res.Body.Close()
-	data, err := ioutil.ReadAll(res.Body)
+	data, err := io.ReadAll(res.Body)
 	if err != nil {
-		c.logger.Error(err)
+		log.Error(err)
 		return nil, err
 	}
 
@@ -89,20 +89,20 @@ func (c collector) fetchMoonrakerHistory(klipperHost string, apiKey string) (*Mo
 
 	err = json.Unmarshal(data, &response)
 	if err != nil {
-		c.logger.Error(err)
+		log.Error(err)
 		return nil, err
 	}
 
 	return &response, nil
 }
-func (c collector) fetchMoonrakerHistoryCurrent(klipperHost string, apiKey string) (*MoonrakerHistoryCurrentPrintResponse, error) {
+func (c Collector) fetchMoonrakerHistoryCurrent(klipperHost string, apiKey string) (*MoonrakerHistoryCurrentPrintResponse, error) {
 	var url = "http://" + klipperHost + "/server/history/list?limit=1&start=0&since=1&order=desc"
-	c.logger.Debug("Collecting metrics from " + url)
+	log.Debug("Collecting metrics from " + url)
 
 	client := &http.Client{}
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
-		c.logger.Error(err)
+		log.Error(err)
 		return nil, err
 	}
 	if apiKey != "" {
@@ -110,13 +110,13 @@ func (c collector) fetchMoonrakerHistoryCurrent(klipperHost string, apiKey strin
 	}
 	res, err := client.Do(req)
 	if err != nil {
-		c.logger.Error(err)
+		log.Error(err)
 		return nil, err
 	}
 	defer res.Body.Close()
-	data, err := ioutil.ReadAll(res.Body)
+	data, err := io.ReadAll(res.Body)
 	if err != nil {
-		c.logger.Error(err)
+		log.Error(err)
 		return nil, err
 	}
 
@@ -124,7 +124,7 @@ func (c collector) fetchMoonrakerHistoryCurrent(klipperHost string, apiKey strin
 
 	err = json.Unmarshal(data, &response)
 	if err != nil {
-		c.logger.Error(err)
+		log.Error(err)
 		return nil, err
 	}
 

--- a/collector/job_queue.go
+++ b/collector/job_queue.go
@@ -4,8 +4,8 @@ package collector
 
 import (
 	"encoding/json"
-	"io/ioutil"
-
+	log "github.com/sirupsen/logrus"
+	"io"
 	"net/http"
 )
 
@@ -20,14 +20,14 @@ type MoonrakerQueuedJob struct {
 	TimeInQueue float64 `json:"time_in_queue"`
 }
 
-func (c collector) fetchMoonrakerJobQueue(klipperHost string, apiKey string) (*MoonrakerJobQueueResponse, error) {
+func (c Collector) fetchMoonrakerJobQueue(klipperHost string, apiKey string) (*MoonrakerJobQueueResponse, error) {
 	var url = "http://" + klipperHost + "/server/job_queue/status"
-	c.logger.Debug("Collecting metrics from " + url)
+	log.Debug("Collecting metrics from " + url)
 
 	client := &http.Client{}
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
-		c.logger.Error(err)
+		log.Error(err)
 		return nil, err
 	}
 	if apiKey != "" {
@@ -35,13 +35,13 @@ func (c collector) fetchMoonrakerJobQueue(klipperHost string, apiKey string) (*M
 	}
 	res, err := client.Do(req)
 	if err != nil {
-		c.logger.Error(err)
+		log.Error(err)
 		return nil, err
 	}
 	defer res.Body.Close()
-	data, err := ioutil.ReadAll(res.Body)
+	data, err := io.ReadAll(res.Body)
 	if err != nil {
-		c.logger.Error(err)
+		log.Error(err)
 		return nil, err
 	}
 
@@ -49,7 +49,7 @@ func (c collector) fetchMoonrakerJobQueue(klipperHost string, apiKey string) (*M
 
 	err = json.Unmarshal(data, &response)
 	if err != nil {
-		c.logger.Error(err)
+		log.Error(err)
 		return nil, err
 	}
 

--- a/collector/process_stats.go
+++ b/collector/process_stats.go
@@ -4,8 +4,8 @@ package collector
 
 import (
 	"encoding/json"
-	"io/ioutil"
-
+	log "github.com/sirupsen/logrus"
+	"io"
 	"net/http"
 )
 
@@ -54,14 +54,14 @@ type MoonrakerSystemMemory struct {
 	Used      int `json:"used"`
 }
 
-func (c collector) fetchMoonrakerProcessStats(klipperHost string, apiKey string) (*MoonrakerProcessStatsQueryResponse, error) {
+func (c Collector) fetchMoonrakerProcessStats(klipperHost string, apiKey string) (*MoonrakerProcessStatsQueryResponse, error) {
 	var url = "http://" + klipperHost + "/machine/proc_stats"
-	c.logger.Debug("Collecting metrics from " + url)
+	log.Debug("Collecting metrics from " + url)
 
 	client := &http.Client{}
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
-		c.logger.Error(err)
+		log.Error(err)
 		return nil, err
 	}
 	if apiKey != "" {
@@ -69,13 +69,13 @@ func (c collector) fetchMoonrakerProcessStats(klipperHost string, apiKey string)
 	}
 	res, err := client.Do(req)
 	if err != nil {
-		c.logger.Error(err)
+		log.Error(err)
 		return nil, err
 	}
 	defer res.Body.Close()
-	data, err := ioutil.ReadAll(res.Body)
+	data, err := io.ReadAll(res.Body)
 	if err != nil {
-		c.logger.Error(err)
+		log.Error(err)
 		return nil, err
 	}
 
@@ -83,7 +83,7 @@ func (c collector) fetchMoonrakerProcessStats(klipperHost string, apiKey string)
 
 	err = json.Unmarshal(data, &response)
 	if err != nil {
-		c.logger.Error(err)
+		log.Error(err)
 		return nil, err
 	}
 

--- a/collector/system_info.go
+++ b/collector/system_info.go
@@ -4,8 +4,8 @@ package collector
 
 import (
 	"encoding/json"
-	"io/ioutil"
-
+	log "github.com/sirupsen/logrus"
+	"io"
 	"net/http"
 )
 
@@ -21,14 +21,14 @@ type MoonrakerSystemInfoQueryResponse struct {
 	} `json:"result"`
 }
 
-func (c collector) fetchMoonrakerSystemInfo(klipperHost string, apiKey string) (*MoonrakerSystemInfoQueryResponse, error) {
+func (c Collector) fetchMoonrakerSystemInfo(klipperHost string, apiKey string) (*MoonrakerSystemInfoQueryResponse, error) {
 	var url = "http://" + klipperHost + "/machine/system_info"
-	c.logger.Debug("Collecting metrics from " + url)
+	log.Debug("Collecting metrics from " + url)
 
 	client := &http.Client{}
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
-		c.logger.Error(err)
+		log.Error(err)
 		return nil, err
 	}
 	if apiKey != "" {
@@ -36,13 +36,13 @@ func (c collector) fetchMoonrakerSystemInfo(klipperHost string, apiKey string) (
 	}
 	res, err := client.Do(req)
 	if err != nil {
-		c.logger.Error(err)
+		log.Error(err)
 		return nil, err
 	}
 	defer res.Body.Close()
-	data, err := ioutil.ReadAll(res.Body)
+	data, err := io.ReadAll(res.Body)
 	if err != nil {
-		c.logger.Error(err)
+		log.Error(err)
 		return nil, err
 	}
 
@@ -50,7 +50,7 @@ func (c collector) fetchMoonrakerSystemInfo(klipperHost string, apiKey string) (
 
 	err = json.Unmarshal(data, &response)
 	if err != nil {
-		c.logger.Error(err)
+		log.Error(err)
 		return nil, err
 	}
 

--- a/collector/temperature_store.go
+++ b/collector/temperature_store.go
@@ -4,8 +4,8 @@ package collector
 
 import (
 	"encoding/json"
-	"io/ioutil"
-
+	log "github.com/sirupsen/logrus"
+	"io"
 	"net/http"
 )
 
@@ -13,14 +13,14 @@ type TemperatureDataQueryResponse struct {
 	Result map[string]interface{} `json:"result"`
 }
 
-func (c collector) fetchTemperatureData(klipperHost string, apiKey string) (*TemperatureDataQueryResponse, error) {
+func (c Collector) fetchTemperatureData(klipperHost string, apiKey string) (*TemperatureDataQueryResponse, error) {
 	var url = "http://" + klipperHost + "/server/temperature_store"
-	c.logger.Debug("Collecting metrics from " + url)
+	log.Debug("Collecting metrics from " + url)
 
 	client := &http.Client{}
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
-		c.logger.Error(err)
+		log.Error(err)
 		return nil, err
 	}
 	if apiKey != "" {
@@ -28,13 +28,13 @@ func (c collector) fetchTemperatureData(klipperHost string, apiKey string) (*Tem
 	}
 	res, err := client.Do(req)
 	if err != nil {
-		c.logger.Error(err)
+		log.Error(err)
 		return nil, err
 	}
 	defer res.Body.Close()
-	data, err := ioutil.ReadAll(res.Body)
+	data, err := io.ReadAll(res.Body)
 	if err != nil {
-		c.logger.Error(err)
+		log.Error(err)
 		return nil, err
 	}
 
@@ -42,7 +42,7 @@ func (c collector) fetchTemperatureData(klipperHost string, apiKey string) (*Tem
 
 	err = json.Unmarshal(data, &response)
 	if err != nil {
-		c.logger.Error(err)
+		log.Error(err)
 		return nil, err
 	}
 

--- a/klipper-exporter.service
+++ b/klipper-exporter.service
@@ -2,13 +2,16 @@
 
 [Unit]
 Description=Prometheus exporter for Klipper.
-After=moonraker.Service
+After=moonraker.service
+StartLimitBurst=6
+StartLimitIntervalSec=5
 
 [Service]
 User=pi
 WorkingDirectory=/home/pi/klipper-exporter
 ExecStart=/home/pi/klipper-exporter/prometheus-klipper-exporter
 Restart=always
+RestartSec=1s
 
 [Install]
 WantedBy=multi-user.target

--- a/main.go
+++ b/main.go
@@ -23,7 +23,7 @@ var (
 	verbose = flag.Bool("verbose", false, "(Deprecated) Enable verbose trace level logging. Use -logging.level instead.")
 )
 
-func handler(w http.ResponseWriter, r *http.Request, logger log.Logger) {
+func handler(w http.ResponseWriter, r *http.Request) {
 	query := r.URL.Query()
 
 	target := query.Get("target")
@@ -38,54 +38,53 @@ func handler(w http.ResponseWriter, r *http.Request, logger log.Logger) {
 	if len(query["modules"]) > 0 {
 		modules = query["modules"]
 	}
-	logger.Infof("Starting metrics collection of %s for %s", modules, target)
+	log.Infof("Starting metrics collection of %s for %s", modules, target)
 
 	// set api key. prometheus.yml > command line arg > environment variable
 	apiKey := ""
 	auth := r.Header.Get("Authorization")
 	if auth != "" && strings.HasPrefix(auth, "APIKEY") {
 		apiKey = strings.Replace(auth, "APIKEY ", "", 1)
-		logger.Debug("Using API key from prometheus.yml authorization configuration")
+		log.Debug("Using API key from prometheus.yml authorization configuration")
 	} else if *klipperApiKey != "" {
 		apiKey = *klipperApiKey
-		logger.Debug("Using API key from -moonraker.apikey command line argument")
+		log.Debug("Using API key from -moonraker.apikey command line argument")
 	} else if apiKey = os.Getenv("MOONRAKER_APIKEY"); apiKey != "" {
-		logger.Debug("Using API key from MOONRAKER_APIKEY environment variable")
+		log.Debug("Using API key from MOONRAKER_APIKEY environment variable")
 	} else {
-		logger.Debug("API key not set")
+		log.Debug("API key not set")
 	}
 
 	registry := prometheus.NewRegistry()
-	c := collector.New(r.Context(), target, modules, apiKey, logger)
+	c := collector.New(r.Context(), target, modules, apiKey)
 	registry.MustRegister(c)
 	h := promhttp.HandlerFor(registry, promhttp.HandlerOpts{})
 	h.ServeHTTP(w, r)
 }
 
 func main() {
-	var logger = log.New()
 	flag.Parse()
 
 	level, err := log.ParseLevel(strings.ToLower(*loggingLevel))
 	if err != nil {
-		logger.Fatalf("Invalid logging level '%s'", *loggingLevel)
+		log.Fatalf("Invalid logging level '%s'", *loggingLevel)
 	}
-	logger.SetLevel(level)
+	log.SetLevel(level)
 
 	// TODO remove when -debug and -verbose options are removed
 	if *debug {
-		logger.Warn("-debug option is deprecated, change to using '-logging.level debug'")
-		logger.SetLevel(log.DebugLevel)
+		log.Warn("-debug option is deprecated, change to using '-logging.level debug'")
+		log.SetLevel(log.DebugLevel)
 	}
 	if *verbose {
-		logger.Warn("-verbose option is deprecated, change to using '-logging.level trace'")
-		logger.SetLevel(log.TraceLevel)
+		log.Warn("-verbose option is deprecated, change to using '-logging.level trace'")
+		log.SetLevel(log.TraceLevel)
 	}
 
 	http.Handle("/metrics", promhttp.Handler())
 	http.HandleFunc("/probe", func(w http.ResponseWriter, r *http.Request) {
-		handler(w, r, *logger)
+		handler(w, r)
 	})
-	logger.Infof("Beginning to serve on port %s", *listenAddress)
-	logger.Fatal(http.ListenAndServe(*listenAddress, nil))
+	log.Infof("Beginning to serve on port %s", *listenAddress)
+	log.Fatal(http.ListenAndServe(*listenAddress, nil))
 }


### PR DESCRIPTION
While I was looking at the other issue, my IDE started notifying me that there were some issues with the code. I fixed those.

* One of these was that a new logger was created and passed forward. This is actually not needed, as far as I remember, in logrus. You can just set the default and use `log` directly. Passing it on, copies a lock that exists inside the logger:

```bash
$ go vet .
# github.com/scross01/prometheus-klipper-exporter
./main.go:26:61: handler passes lock by value: github.com/sirupsen/logrus.Logger contains github.com/sirupsen/logrus.MutexWrap
./main.go:59:59: call of collector.New copies lock value: github.com/sirupsen/logrus.Logger contains github.com/sirupsen/logrus.MutexWrap
./main.go:87:17: call of handler copies lock value: github.com/sirupsen/logrus.Logger contains github.com/sirupsen/logrus.MutexWrap
```

* The `ioutil.ReadAll` was replaced by `io.ReadAll` a while back. It's a drop-in replacement.

* In `New` in collector.go, a `collector` was returned, which should then be exported (start with a capital letter).

* There were some explicit type castings to float64 from a float64, which is reduntant.

* The service's unit file has `restart=Always`. In systemd, this doesn't work as expected. If your service starts up too quickly, and then crashes to quickly, it will trigger the rate limit and stop trying to restart the service. This happened on my system when it crashed over the bug fixed in the previous PR. I added the rate limit configuration to hopefully make sure it doesn't trigger anymore.

I hope the changes in this PR are helpful. Please don't see them as nitpicking or critique on the code, I just can't stand my IDE yelling at me :) 