### PR TITLE
Fix unmarshalling of `total_jobs` value

### DIFF
--- a/collector/history.go
+++ b/collector/history.go
@@ -12,7 +12,7 @@ import (
 type MoonrakerHistoryResponse struct {
 	Result struct {
 		JobTotals struct {
-			Jobs         int64   `json:"total_jobs"`
+			Jobs         float64 `json:"total_jobs"`
 			TotalTime    float64 `json:"total_time"`
 			PrintTime    float64 `json:"total_print_time"`
 			FilamentUsed float64 `json:"total_filament_used"`


### PR DESCRIPTION
This should fix the error `json: cannot unmarshal number 49.0 into Go struct field .result.job_totals.total_jobs of type int64` that happens with the current version of Moonraker.

See https://github.com/scross01/prometheus-klipper-exporter/issues/26 