### PR TITLE
Include custom fan and filament sensors

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -550,6 +550,24 @@ func (c Collector) Collect(ch chan<- prometheus.Metric) {
 				fv.Rpm,
 				fanName)
 		}
+
+		// controller_fan
+		controllerFanLabels := []string{"fan"}
+		controllerFanSpeed := prometheus.NewDesc("klipper_controller_fan_speed", "The speed of the controller fan", controllerFanLabels, nil)
+		controllerFanRpm := prometheus.NewDesc("klipper_controller_fan_rpm", "The RPM of the controller fan", controllerFanLabels, nil)
+		for fk, fv := range result.Result.Status.ControllerFans {
+			fanName := getValidLabelName(fk)
+			ch <- prometheus.MustNewConstMetric(
+				controllerFanSpeed,
+				prometheus.GaugeValue,
+				fv.Speed,
+				fanName)
+			ch <- prometheus.MustNewConstMetric(
+				controllerFanRpm,
+				prometheus.GaugeValue,
+				fv.Rpm,
+				fanName)
+		}
 	}
 }
 

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -532,6 +532,24 @@ func (c Collector) Collect(ch chan<- prometheus.Metric) {
 				v.Value,
 				pinName)
 		}
+
+		// fan_generic
+		genericFanLabels := []string{"fan"}
+		genericFanSpeed := prometheus.NewDesc("klipper_generic_fan_speed", "The speed of the generic fan", genericFanLabels, nil)
+		genericFanRpm := prometheus.NewDesc("klipper_generic_fan_rpm", "The RPM of the generic fan", genericFanLabels, nil)
+		for fk, fv := range result.Result.Status.GenericFans {
+			fanName := getValidLabelName(fk)
+			ch <- prometheus.MustNewConstMetric(
+				genericFanSpeed,
+				prometheus.GaugeValue,
+				fv.Speed,
+				fanName)
+			ch <- prometheus.MustNewConstMetric(
+				genericFanRpm,
+				prometheus.GaugeValue,
+				fv.Rpm,
+				fanName)
+		}
 	}
 }
 

--- a/collector/printer_object.go
+++ b/collector/printer_object.go
@@ -330,7 +330,7 @@ func (c Collector) fetchMoonrakerPrinterObjects(klipperHost string, apiKey strin
 			log.Error(err)
 			return nil, err
 		}
-		log.Infof("Found custom sensors: %+v %+v %+v %+v %+v", ts, tf, op, gf, cf)
+		log.Infof("Found custom sensors: %+v %+v %+v %+v %+v %+v", ts, tf, op, gf, cf, fs)
 		customTemperatureSensors[klipperHost] = *ts
 		customTemperatureFans[klipperHost] = *tf
 		customOutputPins[klipperHost] = *op


### PR DESCRIPTION
I have added support for `fan_generic`, `controller_fan` and `filament_{switch,encoder}_sensor` entities.

![image](https://github.com/scross01/prometheus-klipper-exporter/assets/3594528/daf89322-9940-4665-b1d6-ad23a9d56246)

My use case for generic fans is coordinating hot air recirculation and exhaustion with the overall chamber temperature, and while I was at it I've also included the two types of filament sensors currently available in Klipper. I don't think I've implemented the parsing of the latters in the best way possible, so please feel free to suggest a different approach.